### PR TITLE
Update example to work with PHP 8

### DIFF
--- a/.github/workflows/php_ci.yml
+++ b/.github/workflows/php_ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1, 8.2]
+        php: [7.4, 8.0, 8.1, 8.2]
 
     steps:
       - name: Checkout
@@ -34,3 +34,15 @@ jobs:
 
       - name: PHP tests
         run: ./vendor/bin/phpunit --process-isolation tests
+
+      - name: Composer install example
+        working-directory: example
+        run: composer install
+
+      - name: Inject dummy example config
+        working-directory: example
+        run: printf "[duo]\nclient_id=DIAAAAAAAAAAAAAAAAAA\nclient_secret=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\napi_hostname=example.duosecurity.com\nredirect_uri=http://localhost:8080\nfailmode=closed\n" > ./duo.conf
+
+      - name: Ensure example runs
+        working-directory: example
+        run: php index.php

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ What's included:
 * `tests` - Test cases
 
 ## Getting started
-This library requires PHP 7.3 or later
+This library requires PHP 7.4 or later
 
 To use SDK in your existing developing environment, install it from Packagist
 ```

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "ext-curl": "*",
         "ext-json": "*",
         "firebase/php-jwt": "^6.0"

--- a/example/composer.json
+++ b/example/composer.json
@@ -1,9 +1,9 @@
 {
   "require": {
-    "slim/slim": "4.7.1",
-    "slim/psr7": "1.3.0",
-    "slim/php-view": "3.0.0",
-    "bryanjhv/slim-session": "4.0",
+    "slim/slim": "4.12.0",
+    "slim/psr7": "1.6.1",
+    "slim/php-view": "3.2.0",
+    "bryanjhv/slim-session": "4.1.2",
     "duosecurity/duo_universal_php": "@dev"
   },
   "repositories": [

--- a/example/dockerfile
+++ b/example/dockerfile
@@ -1,9 +1,11 @@
-FROM php:7
+FROM php:8
 EXPOSE 8080
 RUN apt update && apt install -y unzip wget
 WORKDIR /root
 RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/885ece8a6e1370b204b89b7a542169d25aa21177/web/installer -O - -q | php -- --quiet
-ADD . /src
+
+ADD ./composer.json /src/composer.json
 WORKDIR /src
 RUN /root/composer.phar update
+ADD . /src
 ENTRYPOINT ["php", "-S", "0.0.0.0:8080"]

--- a/example/index.php
+++ b/example/index.php
@@ -21,7 +21,7 @@ try {
         $config['api_hostname'],
         $config['redirect_uri'],
         true,
-        $config['http_proxy'],
+        $config['http_proxy'] ?? null,
     );
 } catch (DuoException $e) {
     throw new ErrorException("*** Duo config error. Verify the values in duo.conf are correct ***\n" . $e->getMessage());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updates the example to be compatible with PHP 8 by updating the slim dependencies and fixing a warning with the http_proxy array access. Slim no longer supports PHP 7.3, so also dropping support for that. (PHP 7.3 was EOL 12/2021. PHP 7.4 is also EOL, but still heavily used)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The example should work with all currently-supported versions of PHP.

## How Has This Been Tested?
<!--- Please describe how you tested your changes, or what tests were added -->
Manually verified locally, and added basic example app validation to the CI testing.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
