### PR TITLE
Remove 7.3 from CI tests

### DIFF
--- a/.github/workflows/php_ci.yml
+++ b/.github/workflows/php_ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1, 8.2]
+        php: [7.4, 8.0, 8.1, 8.2]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
All PHP 7 versions are EOL now. PHP 7.3 is incompatible with the latest slim-php versions (used by the example app), so removing it from CI testing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes, or what tests were added -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
