### PR TITLE
Allow custom user agent specification

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -63,6 +63,7 @@ class Client
     public $redirect_url;
     public $use_duo_code_attribute;
     private $client_secret;
+    private $user_agent_extension;
 
     /**
      * Retrieves exception message for DuoException from HTTPS result message.
@@ -190,6 +191,34 @@ class Client
         $this->redirect_url = $redirect_url;
         $this->use_duo_code_attribute = $use_duo_code_attribute;
         $this->http_proxy = $http_proxy;
+        $this->user_agent_extension = null;
+    }
+
+    /**
+     * Append custom information to the user agent string.
+     *
+     * @param string $user_agent_extension Custom user agent information
+     *
+     * @return void
+     */
+    public function appendToUserAgent(string $user_agent_extension): void
+    {
+        $this->user_agent_extension = trim($user_agent_extension);
+    }
+
+    /**
+     * Build the complete user agent string.
+     *
+     * @return string The complete user agent string
+     */
+    private function buildUserAgent(): string
+    {
+        $base_user_agent = self::USER_AGENT . " php/" . phpversion() . " "
+                         . php_uname();
+        if (!empty($this->user_agent_extension)) {
+            return $base_user_agent . " " . $this->user_agent_extension;
+        }
+        return $base_user_agent;
     }
 
     /**
@@ -282,7 +311,7 @@ class Client
     public function exchangeAuthorizationCodeFor2FAResult(string $duoCode, string $username, ?string $nonce = null): array
     {
         $token_endpoint = "https://" . $this->api_host . self::TOKEN_ENDPOINT;
-        $useragent = self::USER_AGENT . " php/" . phpversion() . " " . php_uname();
+        $useragent = $this->buildUserAgent();
         $jwt = $this->createJwtPayload($token_endpoint);
         $request = ["grant_type" => self::GRANT_TYPE,
                     "code" => $duoCode,


### PR DESCRIPTION
## Description
Added support for extension of user agent strings. Users can now extend a user agent via appendToUserAgent() method of Client class.

## Motivation and Context
This change was specifically requested to allow `duo_universal_wordpress` (the WordPress plugin) to specify its own user agent when making requests to Duo's servers.

## How Has This Been Tested?
- All existing tests pass
- New test coverage added: 
  - `testAppendToUserAgent()` - verifies that the user agent extension can be set and is included in requests
  - `testUserAgentWithoutExtension()` - verifies that user agent works correctly without any extension
  - `testAppendToUserAgentEmpty()` - verifies that empty user agent extension is handled correctly
- Manual testing with scripts using both default and custom user agent functionality

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
