### PR TITLE
Add PHP 8.4 and 8.5 in CI

### DIFF
--- a/.github/workflows/php_ci.yml
+++ b/.github/workflows/php_ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2, 8.3]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add PHP 8.4 and 8.5 version in the CI to run tests again these new PHP version.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To have a proof that it works on both version without any issues/deprecations.

## How Has This Been Tested?
<!--- Please describe how you tested your changes, or what tests were added -->
No tests required

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
