### PR TITLE
Add firebase/php-jwt v7.* support to fix CVE-2025-45769

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 vendor
+composer.lock
 *.swp
 *.swo
 .idea

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=7.4",
         "ext-curl": "*",
         "ext-json": "*",
-        "firebase/php-jwt": "^6.0"
+        "firebase/php-jwt": "^6.0 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The package `firebase/php-jwt` contains CVE-2025-45769 security vulnerability and only fixed in version 7. This library depends on v6 and require support for v7 as well.

## Motivation and Context
Security issue.

## How Has This Been Tested?
Via unit test. It's failing BTW because major changes in the php-jwt package.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

The test cases are failing with `Provided key is too short` error. And upon checking the client secret length is what is recommended. I think package needs a major version bump with only v7. If you agree I can update PR to remove v6 requirements.
