### PR TITLE
Fixup example app

### DIFF
--- a/.github/workflows/php_ci.yml
+++ b/.github/workflows/php_ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
+        php: [8.2, 8.3, 8.4, 8.5]
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ What's included:
 * `tests` - Test cases
 
 ## Getting started
-This library requires PHP 7.4 or later
+This library requires PHP 8.2 or later
 
 To use SDK in your existing developing environment, install it from Packagist
 ```

--- a/example/composer.json
+++ b/example/composer.json
@@ -1,7 +1,7 @@
 {
   "require": {
     "slim/slim": "4.12.0",
-    "slim/psr7": "1.6.1",
+    "slim/psr7": "^1.7",
     "slim/php-view": "3.2.0",
     "bryanjhv/slim-session": "4.1.2",
     "duosecurity/duo_universal_php": "@dev"

--- a/example/index.php
+++ b/example/index.php
@@ -1,5 +1,7 @@
 <?php
 
+ob_start();
+
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Logger;

--- a/example/index.php
+++ b/example/index.php
@@ -36,6 +36,13 @@ $errorMiddleware = $app->addErrorMiddleware(true, true, true, $logger);
 $app->add(new Session());
 
 $app->get('/', function (Request $request, Response $response, $args) {
+    # Helpfully redirect to `localhost` if accessed via 127.0.0.1 or 0.0.0.0 to ensure session cookie consistency and avoid state errors.
+    # (The url used in redirect_uri must match the url used to access the app)
+    if (in_array($request->getUri()->getHost(), ['127.0.0.1', '0.0.0.0'])) {
+        header('Location: http://localhost:' . $request->getUri()->getPort());
+        exit();
+    }
+
     $renderer = new PhpRenderer('./templates');
     $args["message"] = "This is a demo";
     return $renderer->render($response, "login.php", $args);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The example had a few minor issues:
- On first website load, a few PHP error messages were displayed in the HTML. These are now fixed.
- The PHP Dev server encourages accessing the example site using `0.0.0.0:8080`, but the example must be accessed using `localhost:8080` to preserve the session, since that's the `redirect_uri` in the sample duo.conf. The example app will now auto-redirect to localhost to prevent this error scenario.
- One of the required dependency updates no longer supports PHP7. Removed PHP 7.4 - 8.1 from CI, as they are all EOL.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Better quality-of-life when using the example app

## How Has This Been Tested?
<!--- Please describe how you tested your changes, or what tests were added -->
Tested example locally.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
