### PR TITLE
Add ci_success job to simplify branch protection

### DIFF
--- a/.github/workflows/php_ci.yml
+++ b/.github/workflows/php_ci.yml
@@ -46,3 +46,10 @@ jobs:
       - name: Ensure example runs
         working-directory: example
         run: php index.php
+
+  ci_success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    needs: [ci]
+    steps:
+      - run: echo "All CI jobs passed successfully"


### PR DESCRIPTION
## Summary
- Add a single `CI Success` job that depends on all matrix jobs passing
- This creates one status check instead of individual checks for each PHP version

## Benefits
- Branch protection settings will only need to require the single `CI Success` check
- Adding or removing PHP versions from the matrix won't require updating branch protection rules
- Simplifies maintenance when deprecating old PHP versions

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, update branch protection to require only `CI Success` instead of individual PHP version checks