### PR TITLE
Refactor to support firebase/php-jwt 7.X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 vendor
+composer.lock
 *.swp
 *.swo
 .idea

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=7.4",
         "ext-curl": "*",
         "ext-json": "*",
-        "firebase/php-jwt": "^6.0"
+        "firebase/php-jwt": "^6.0 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -34,6 +34,7 @@ class Client
     const DEFAULT_STATE_LENGTH = 36;
     const CLIENT_ID_LENGTH = 20;
     const CLIENT_SECRET_LENGTH = 40;
+    const HS512_MIN_KEY_LENGTH = 64;
     const JWT_EXPIRATION = 300;
     const JWT_LEEWAY = 60;
     const SUCCESS_STATUS_CODE = 200;
@@ -121,6 +122,18 @@ class Client
         return json_decode($result, true);
     }
 
+    /**
+     * Pads the client secret to meet minimum key length requirements for HS512.
+     * HMAC-SHA512 in php-jwt v7+ requires 64-byte keys. Padding with null bytes
+     * doesn't affect HMAC output because HMAC internally pads to block size.
+     *
+     * @return string The padded client secret
+     */
+    private function getPaddedSecret(): string
+    {
+        return str_pad($this->client_secret, self::HS512_MIN_KEY_LENGTH, "\0");
+    }
+
     private function createJwtPayload(string $audience): string
     {
         $date = new \DateTime();
@@ -132,7 +145,7 @@ class Client
                       "iat" => $current_date,
                       "exp" => $current_date + self::JWT_EXPIRATION
         ];
-        return JWT::encode($payload, $this->client_secret, self::SIG_ALGORITHM);
+        return JWT::encode($payload, $this->getPaddedSecret(), self::SIG_ALGORITHM);
     }
 
     /**
@@ -283,7 +296,7 @@ class Client
             'use_duo_code_attribute' => $this->use_duo_code_attribute
         ];
 
-        $jwt = JWT::encode($payload, $this->client_secret, self::SIG_ALGORITHM);
+        $jwt = JWT::encode($payload, $this->getPaddedSecret(), self::SIG_ALGORITHM);
         $allArgs = [
             'response_type' => 'code',
             'client_id' => $this->client_id,
@@ -334,7 +347,7 @@ class Client
 
         try {
             JWT::$leeway = self::JWT_LEEWAY;
-            $jwt_key = new Key($this->client_secret, self::SIG_ALGORITHM);
+            $jwt_key = new Key($this->getPaddedSecret(), self::SIG_ALGORITHM);
             $token_obj = JWT::decode($result['id_token'], @$jwt_key);
             /* JWT::decode returns a PHP object, this will turn the object into a multidimensional array */
             $token = json_decode(json_encode($token_obj), true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
firebase/php-jwt 7.0 enforces a minimum key length of 64 on JWTs using HMAC512, but Duo uses a length of 40. The recommended solution is to pad out the key to the required size. (We had this same situation in duo_universal_csharp https://github.com/duosecurity/duo_universal_csharp/pull/23 ) . This allows the client to support both php-jwt 6.X and 7.X.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Support for newer versions of dependencies. (Note that this issue was labelled as a CVE in firebase/php-jwt, but is not an actual vulnerability https://github.com/firebase/php-jwt/issues/605 )

## How Has This Been Tested?
Tested locally both with firebase/php-jwt 6.X and 7.X.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Thank you to @ishanvyas22 for bringing this issue to our attention!